### PR TITLE
adds browser geo API key to application.html

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
     <%= render 'shared/flashes' %>
     <%= yield %>
     <%= javascript_include_tag 'application' %>
-    <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=AIzaSyDq3YMQdAcDvJ4SZ_RKRUsG8rl9cW5n0Q4" %>
+<%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?libraries=places&key=#{ENV['GOOGLE_API_BROWSER_KEY']}" %>
     <%= javascript_pack_tag 'application' %>
     <%= javascript_pack_tag "map" %>
   </body>


### PR DESCRIPTION
add this to .env...

add GOOGLE_API_BROWSER_KEY=(i will send key on slack)

post this line from terminal once Heroku is working...

heroku config:set GOOGLE_API_BROWSER_KEY=(i will send key on slack)

